### PR TITLE
Indicate that we don't want XML secure parsing turned on

### DIFF
--- a/src/main/java/com/faendir/rhino_android/AndroidContextFactory.java
+++ b/src/main/java/com/faendir/rhino_android/AndroidContextFactory.java
@@ -64,4 +64,12 @@ public class AndroidContextFactory extends ContextFactory {
         super.onContextReleased(cx);
         ((BaseAndroidClassLoader) cx.getApplicationClassLoader()).reset();
     }
+
+    @Override
+    protected boolean hasFeature(Context cx, int featureIndex) {
+        if (featureIndex == Context.FEATURE_ENABLE_XML_SECURE_PARSING) {
+            return false;
+        }
+        return super.hasFeature(cx, featureIndex);
+    }
 }


### PR DESCRIPTION
See https://github.com/MarcusWolschon/osmeditor4android/issues/1273 this is required for 1.7.12 and later to work. Arguably this could be made user settable in some form.

There are currently quite a few issues with the tests that are however not related to this PR.